### PR TITLE
Add a snippet to avoid resource busy error

### DIFF
--- a/lego_dimensions_gateway.py
+++ b/lego_dimensions_gateway.py
@@ -47,6 +47,11 @@ class Gateway():
         if dev is None:
             raise ValueError('Device not found')
 
+        self.reattach = False
+        if dev.is_kernel_driver_active(0):
+            self.reattach = True
+            dev.detach_kernel_driver(0)
+
         # set the active configuration. With no arguments, the first
         # configuration will be the active one
         dev.set_configuration()
@@ -70,6 +75,13 @@ class Gateway():
             if result >= 256:
                 result -= 256
         return result
+
+    def __del__(self):
+        """
+        Reattach the device when we are done with the object
+        """
+        if self.reattach:
+            self.dev.attach_kernel_driver(0)
 
     def pad_message(self,message):
         """Pad a message to 32 bytes"""


### PR DESCRIPTION
I tried the utility you had today and found that I ran into following error

```
usr.core.USBError: [Errno 16] Resource busy
```

After some digging around I found that I need to execute `detach_kernel_driver` before `set_configuration`, and we potentially need to run `attach_kernel_driver` when we clean up the object